### PR TITLE
feature: Save audio page wise or full book

### DIFF
--- a/audiobook/main.py
+++ b/audiobook/main.py
@@ -70,9 +70,11 @@ class AudioBook:
         json_filename = os.path.basename(input_book_path).split(".")[0] + ".json"
         
         if os.path.exists(os.path.join(BOOK_DIR, json_filename)):
+            print("Book already exists in library, reading from library")
             json_book = load_json(os.path.join(BOOK_DIR, json_filename))
             pages = len(json_book)
             return json_book, pages
+        
         elif input_book_path.endswith(".pdf"):
             json_book, pages = pdf_to_json(input_book_path, password)
         elif input_book_path.endswith(".txt"):
@@ -83,33 +85,39 @@ class AudioBook:
             json_book, pages = mobi_to_json(input_book_path)
         elif input_book_path.startswith("http"):
             json_book, pages = html_to_json(input_book_path)
-            
+        
         write_json_file(json_book, os.path.join(BOOK_DIR, json_filename))
 
         return json_book, pages
 
-    def save_audio(self, input_book_path, password=None):
+    def save_audio(self, input_book_path, password=None, save_page_wise=False):
         """ method to save audio files in folder """
-        json_book, pages = self.create_json_book(input_book_path, password)
+        json_book, _ = self.create_json_book(input_book_path, password)
         
         book_name = os.path.basename(input_book_path).split(".")[0]
         os.makedirs(book_name, exist_ok=True)
         
         print('Saving audio files in folder: {}'.format(book_name))
-        for page_num, text in tqdm(json_book.items()):
-            self.engine.save_to_file(text, os.path.join(book_name, 
-                                                        book_name + 
-                                                        "_page_" + 
-                                                        (str(page_num)) + 
-                                                        ".mp3"))
+        
+        if save_page_wise:
+            for page_num, text in tqdm(json_book.items()):
+                self.engine.save_to_file(text, os.path.join(book_name, 
+                                                            book_name + 
+                                                            "_page_" + 
+                                                            (str(page_num)) + 
+                                                            ".mp3"))
+                self.engine.runAndWait()
+
+        elif not save_page_wise:
+            all_text = " ".join([text for text in json_book.values()])
+            self.engine.save_to_file(all_text, os.path.join(book_name, book_name + ".mp3"))
             self.engine.runAndWait()
-    
+            
     def read_book(self, input_book_path, password=None):
         """ method to read the book 
         
         input_book_path: filepath, url path or book name
         """
-        
         json_book, pages = self.create_json_book(input_book_path, password)
         
         speak_text(self.engine, f"The book has total {str(pages)} pages!")


### PR DESCRIPTION
## Changelog

1. Now Users can Download Audiobooks as a page-wise or full book. Earlier it was only a saving page wise and the user need another library to merge all audio. It's fixed in this PR.
2. Docs Updated for the Save audio function

```python
from audiobook import AudioBook
# argument: Speech-Speed="slow/normal/fast", volume = 0.0 to 1.0
ab = AudioBook(speed="normal", volume=1.0) 

# save_page_wise audio/whole book in one mp3 file
ab.save_audio(self, input_book_path, password=None, save_page_wise=False): 
```

@DrakeEntity Thanks to him for the suggestion.