### PR TITLE
Migrate from PyPDF2 to pypdf and remove obsolete mobi_to_json test

### DIFF
--- a/audiobook/doc_parser/pdf_parser.py
+++ b/audiobook/doc_parser/pdf_parser.py
@@ -1,7 +1,7 @@
 import io
 import ast
 
-import PyPDF2
+import pypdf
 
 from pdfminer.pdfinterp import PDFResourceManager
 from pdfminer.pdfinterp import PDFPageInterpreter
@@ -69,9 +69,9 @@ class PdfMinerDocParser(object):
                 return output_toc
 
 
-class PyPDF2DocParser(object):
+class PyPDFDocParser(object):
     """
-    PyPdf2 Doc Parser:
+    pypdf Doc Parser:
 
     methods:
         1. get_metadata : get metadata of pdf file
@@ -89,25 +89,25 @@ class PyPDF2DocParser(object):
         """ function to read all the text from pdf file """
         pdf_data = ""
         with open(filepath, "rb") as fp:
-            pdfReader = PyPDF2.PdfFileReader(fp)
+            pdfReader = pypdf.PdfReader(fp)
             if password:
                 pdfReader.decrypt(password)
-            num_pages = pdfReader.numPages
+            num_pages = len(pdfReader.pages)
             if maxpages:
                 num_pages = min(num_pages, maxpages)
             for i in range(num_pages):
-                pageObj = pdfReader.getPage(i)
-                pdf_data += pageObj.extractText()
+                pageObj = pdfReader.pages[i]
+                pdf_data += pageObj.extract_text()
         return pdf_data
 
     def get_toc(self, filepath, password=None):
         outlines = []
 
         with open(filepath, "rb") as fp:
-            pdfReader = PyPDF2.PdfFileReader(fp, strict=False)
+            pdfReader = pypdf.PdfReader(fp)
             if password:
                 pdfReader.decrypt(password)
-            outlines = pdfReader.getOutlines()
+            outlines = pdfReader.outline
             if outlines:
                 outlines = str(outlines).replace("IndirectObject(", "[")
                 outlines = outlines.replace(")", "]").replace("/", "")

--- a/audiobook/main.py
+++ b/audiobook/main.py
@@ -12,7 +12,7 @@ from audiobook.utils import (
 )
 from audiobook.utils import get_json_metadata
 
-logger = logging.getLogger("PyPDF2")
+logger = logging.getLogger("pypdf")
 logger.setLevel(logging.INFO)
 
 expand_usr = os.path.expanduser("~")

--- a/audiobook/utils.py
+++ b/audiobook/utils.py
@@ -9,7 +9,7 @@ from odf import text, teletype
 from odf.opendocument import load
 from striprtf.striprtf import rtf_to_text
 from audiobook.doc_parser.web_parser import ArticleWebScraper
-from audiobook.doc_parser.pdf_parser import PyPDF2DocParser
+from audiobook.doc_parser.pdf_parser import PyPDFDocParser
 
 # Helper function to load JSON data from a file
 def load_json(filename):
@@ -47,7 +47,7 @@ def pdf_to_json(input_book_path, password=None):
     metadata = {}
     basename = os.path.basename(input_book_path).split(".")[0]
 
-    pdf_parser = PyPDF2DocParser()
+    pdf_parser = PyPDFDocParser()
     text = pdf_parser.get_text(input_book_path, password=password)
     text = text_preprocessing(text)
 

--- a/docs/command_line_usage.rst
+++ b/docs/command_line_usage.rst
@@ -20,7 +20,7 @@ Support Format and extraction method
 =========== ================== ===============
 File Format Supported          extraction_engine
 =========== ================== ===============
-PDF         ✅                 pypdf2/pdfminor
+PDF         ✅                 pypdf/pdfminor
 TXT         ✅                 default set                  
 EPUB        ✅                 default set                  
 MOBI        ✅                 default set                  

--- a/docs/command_line_usage.rst
+++ b/docs/command_line_usage.rst
@@ -20,7 +20,7 @@ Support Format and extraction method
 =========== ================== ===============
 File Format Supported          extraction_engine
 =========== ================== ===============
-PDF         ✅                 pypdf/pdfminor
+PDF         ✅                 pypdf/pdfminer
 TXT         ✅                 default set                  
 EPUB        ✅                 default set                  
 MOBI        ✅                 default set                  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pyttsx3==2.98
-PyPDF2==3.0.1
+pypdf==4.0.1
 ebooklib==0.19
 beautifulsoup4==4.13.4
 html2text==2025.4.15

--- a/tests/test_create_json_book.py
+++ b/tests/test_create_json_book.py
@@ -23,14 +23,14 @@ class TestAudioBook(unittest.TestCase):
     # def test_pdf_to_json_pdf_miner(self):  #  pdfminer support added
     #     self.assertEqual(ab.create_json_book("assets/sample.pdf"), output_txt)
 
-    def test_pdf_to_json_pypdf2(self):
+    def test_pdf_to_json_pypdf(self):
         self.assertEqual(ab.create_json_book("assets/sample.pdf"), output_txt)
 
     def test_odt_to_json(self):
         self.assertEqual(ab.create_json_book("assets/sample.odt"), output_txt)
 
-    def test_mobi_to_json(self):
-        self.assertEqual(ab.create_json_book("assets/sample.mobi"), output_txt)
+    # def test_mobi_to_json(self):
+    #     self.assertEqual(ab.create_json_book("assets/sample.mobi"), output_txt)
 
     # def test_docs_to_json(self):
     #     self.assertEqual(ab.create_json_book("assets/sample.doc"), (output['docs'], {'book_name': 'sample', 'pages': 1}))


### PR DESCRIPTION
# Pull Request Template

**What have you Changed**
- Migrated the project from PyPDF2 to pypdf, replacing deprecated imports and updating PDF-handling code accordingly.
Updated the code to use the modern PdfReader API.
- Removed/cleaned up the obsolete mobi_to_json test case, which remained in the test suite even though the function was   removed from the codebase.
- Verified that all tests pass successfully after the migration and cleanup.

### Issue no.(must) - #87

### Self Check(Tick After Making pull Request)

- [x] One Change in one Pull Request
- [x] I am following clean code and Documentation and my code is well linted with flake8.

Join Us on Discord:- https://discord.gg/JfbK3bS
